### PR TITLE
Fixed compilation of included LESS files

### DIFF
--- a/classes/Less/Core.php
+++ b/classes/Less/Core.php
@@ -167,6 +167,8 @@ class Less_Core
 		foreach($files as $file)
 		{
 			$data .= file_get_contents($file);
+			$less = new lessc($file);
+			$data .= $less->parse();
 		}
 
 		echo $data;


### PR DESCRIPTION
If I have the settings set to no compile, it renders the LESS and combines the files... However, if I turn on the compile option, it will not process the files in the same way before combining them.  For instance if you have a @import 'libs/lesshelper.less'; It will simply use that line, not process and include it.
